### PR TITLE
GetInfoResponse version parameter

### DIFF
--- a/bridge_back/backend/session.py
+++ b/bridge_back/backend/session.py
@@ -49,6 +49,7 @@ class Session:
         self.users[host_id].position = PlayerDirection.NORTH
         self.created = datetime.now()
         self.started = False
+        self.version = 0
 
     def join(self, user_id: UserId):
         if len(self.users) >= 4:


### PR DESCRIPTION
GetInfoResponse ma pole version, żeby na froncie dane po requestach po swapie nie były nadpisywane przez useGetLobby bez zaktualizowanych pozycji. Nie wiem czy dobre podejście, ale zdaje się działać.